### PR TITLE
fix:trim down excess data in api payload

### DIFF
--- a/src/ChemDec.Api/Controllers/Handlers/ShipmentHandler.cs
+++ b/src/ChemDec.Api/Controllers/Handlers/ShipmentHandler.cs
@@ -672,7 +672,7 @@ namespace ChemDec.Api.Controllers.Handlers
             var savedShipment = this.GetShipment(shipment.Id);
             var operation = Operation.SaveEvaluation; //checks same as approval
             var details = DetailedOperation.SavedEvaluation;
-
+            shipment.Receiver = db.Installations.Where(w => w.Id == savedShipment.ReceiverId).ProjectTo<PlantReference>(mapper.ConfigurationProvider).FirstOrDefault();
             var validationErrors = CheckIfUserCanSaveEvaluation(savedShipment, shipment, user);
             if (validationErrors != null && validationErrors.Any()) return (null, validationErrors);
 
@@ -776,7 +776,8 @@ namespace ChemDec.Api.Controllers.Handlers
         public async Task<(Shipment, IEnumerable<string>)> SaveOrUpdate(Shipment shipment, Initiator initiator, Operation operation, DetailedOperation details, string comment, string attachment, List<IFormFile> attachments = null, Guid? deleteAttachmentId = null)
         {
             var validationErrors = new List<string>();
-
+            var recSender = db.Installations.FirstOrDefault(w => w.Id == shipment.SenderId);
+            shipment.Receiver = db.Installations.Where(w => w.Id == recSender.ShipsToId).ProjectTo<PlantReference>(mapper.ConfigurationProvider).FirstOrDefault();
             var user = await userService.GetCurrentUser();
             if (user == null)
             {

--- a/src/IntegrationTests/Fixtures/TestSetupFixture.cs
+++ b/src/IntegrationTests/Fixtures/TestSetupFixture.cs
@@ -153,7 +153,7 @@ public class TestSetupFixture : IAsyncLifetime, IDisposable
 
     public async Task InitializeAsync()
     {
-        await Task.CompletedTask;
+        await Task.Delay(1).ConfigureAwait(false);
     }
 
     public async Task DisposeAsync()

--- a/src/IntegrationTests/Fixtures/TestSetupFixture.cs
+++ b/src/IntegrationTests/Fixtures/TestSetupFixture.cs
@@ -153,7 +153,7 @@ public class TestSetupFixture : IAsyncLifetime, IDisposable
 
     public async Task InitializeAsync()
     {
-        
+        await Task.CompletedTask;
     }
 
     public async Task DisposeAsync()

--- a/src/IntegrationTests/Fixtures/TestSetupFixture.cs
+++ b/src/IntegrationTests/Fixtures/TestSetupFixture.cs
@@ -153,7 +153,7 @@ public class TestSetupFixture : IAsyncLifetime, IDisposable
 
     public async Task InitializeAsync()
     {
-        await Task.Delay(1).ConfigureAwait(false);
+        await Task.CompletedTask;
     }
 
     public async Task DisposeAsync()

--- a/src/IntegrationTests/Fixtures/TestSetupFixture.cs
+++ b/src/IntegrationTests/Fixtures/TestSetupFixture.cs
@@ -153,7 +153,7 @@ public class TestSetupFixture : IAsyncLifetime, IDisposable
 
     public async Task InitializeAsync()
     {
-
+        await Task.CompletedTask;
     }
 
     public async Task DisposeAsync()

--- a/src/IntegrationTests/Fixtures/TestSetupFixture.cs
+++ b/src/IntegrationTests/Fixtures/TestSetupFixture.cs
@@ -153,7 +153,7 @@ public class TestSetupFixture : IAsyncLifetime, IDisposable
 
     public async Task InitializeAsync()
     {
-        await Task.CompletedTask;
+        
     }
 
     public async Task DisposeAsync()


### PR DESCRIPTION
fix/trim down excess data in api payload
#5 
Removed the unnecessary data from API Payload like 'Sender' and 'Receiver' fields and handled their dependencies from backend side.