### PR TITLE
chore: remove email from test

### DIFF
--- a/src/ChemDec.Api/appsettings.json
+++ b/src/ChemDec.Api/appsettings.json
@@ -16,7 +16,7 @@
   "env": "Local",
   "build": "Empty build",
   "smtpPw": "SetFromKeyvault",
-  "chemicalEmail": "mikkl@equinor.com",
+  "chemicalEmail": "gm_chemcom@equinor.com",
   "FromEmailAddress": "",
   "released": "",
   "azure": {


### PR DESCRIPTION
I'm recieving notification emails that are sent in local enviornment to my email. You might want to disregard this PR if you have some other place you want these to end up. 

But should work to send the tests to the Group email that you can all have access to and inspect. 