### PR TITLE
chore: increase memory in prod

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -33,7 +33,7 @@ spec:
           monitoring: true
           resources:
             requests:
-              memory: "256Mi"
+              memory: "368Mi"
               cpu: "100m"
             limits:
               memory: "512Mi"
@@ -50,7 +50,7 @@ spec:
           monitoring: true
           resources:
             requests:
-              memory: "256Mi"
+              memory: "512Mi"
               cpu: "100m"
             limits:
               memory: "512Mi"


### PR DESCRIPTION
Increase memory slightly in dev and double it in production to avoid warnings of excessive memory usage in Radix.

#202 